### PR TITLE
Adds formatchecker to validate the format of json schema fields

### DIFF
--- a/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
+++ b/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
@@ -242,13 +242,10 @@ class OrchestratorRequires(Object):
 
     @staticmethod
     def _uri_validator(uri):
-        try:
-            result = urlparse(uri)
-            if not all([result.scheme, result.netloc]):
-                raise ValueError
-            return True
-        except ValueError:
-            raise exceptions.ValidationError(f"{uri} is not a valid URI")
+        result = urlparse(uri)
+        if not all([result.scheme, result.netloc]):
+            return False
+        return True
 
     @staticmethod
     def _relation_data_is_valid(remote_app_relation_data: dict) -> bool:

--- a/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
+++ b/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
@@ -99,8 +99,9 @@ if __name__ == "__main__":
 
 
 import logging
+from urllib.parse import urlparse
 
-from jsonschema import exceptions, validate  # type: ignore[import]
+from jsonschema import FormatChecker, exceptions, validate  # type: ignore[import]
 from ops.charm import CharmBase, CharmEvents, RelationChangedEvent
 from ops.framework import EventBase, EventSource, Handle, Object
 
@@ -240,9 +241,25 @@ class OrchestratorRequires(Object):
         )
 
     @staticmethod
-    def _relation_data_is_valid(remote_app_relation_data: dict) -> bool:
+    def _uri_validator(uri):
         try:
-            validate(instance=remote_app_relation_data, schema=REQUIRER_JSON_SCHEMA)
+            result = urlparse(uri)
+            if not all([result.scheme, result.netloc]):
+                raise ValueError
+            return True
+        except ValueError:
+            raise exceptions.ValidationError(f"{uri} is not a valid URI")
+
+    @staticmethod
+    def _relation_data_is_valid(remote_app_relation_data: dict) -> bool:
+        format_checker = FormatChecker()
+        format_checker.checks("uri")(OrchestratorRequires._uri_validator)
+        try:
+            validate(
+                instance=remote_app_relation_data,
+                schema=REQUIRER_JSON_SCHEMA,
+                format_checker=format_checker,
+            )
             return True
         except exceptions.ValidationError:
             return False

--- a/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
+++ b/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
@@ -241,7 +241,7 @@ class OrchestratorRequires(Object):
         )
 
     @staticmethod
-    def _uri_validator(uri):
+    def _uri_validator(uri) -> bool:
         result = urlparse(uri)
         if not all([result.scheme, result.netloc]):
             return False

--- a/tests/unit/charms/magma_orchestrator_interface/v0/test_magma_orchestrator_interface_requirer.py
+++ b/tests/unit/charms/magma_orchestrator_interface/v0/test_magma_orchestrator_interface_requirer.py
@@ -64,6 +64,37 @@ class Test(unittest.TestCase):
         self.assertEqual(orchestrator_available_event.fluentd_port, fluentd_port)
 
     @patch(f"{BASE_CHARM_DIR}._on_orchestrator_available")
+    def test_given_orchestrator_information_in_relation_data_when_relation_changed_and_schema_validation_fails_then_orchestrator_available_event_is_not_emitted(  # noqa: E501
+        self, patch_on_orchestrator_available
+    ):
+        remote_app = "magma-orc8r-provider"
+        relation_id = self.harness.add_relation(
+            relation_name=self.relation_name, remote_app=remote_app
+        )
+
+        root_ca_certificate = "whatever certificate"
+        wrong_orchestrator_address = "not a url"
+        orchestrator_port = 123
+        bootstrapper_address = "http://bootstrapper.com"
+        bootstrapper_port = 456
+        fluentd_address = "http://fluentd.com"
+        fluentd_port = 789
+        remote_app_relation_data = {
+            "root_ca_certificate": root_ca_certificate,
+            "orchestrator_address": wrong_orchestrator_address,
+            "orchestrator_port": str(orchestrator_port),
+            "bootstrapper_address": bootstrapper_address,
+            "bootstrapper_port": str(bootstrapper_port),
+            "fluentd_address": fluentd_address,
+            "fluentd_port": str(fluentd_port),
+        }
+        self.harness.update_relation_data(
+            relation_id=relation_id, app_or_unit=remote_app, key_values=remote_app_relation_data
+        )
+
+        patch_on_orchestrator_available.assert_not_called()
+
+    @patch(f"{BASE_CHARM_DIR}._on_orchestrator_available")
     def test_given_orchestrator_information_not_in_relation_data_when_relation_changed_then_orchestrator_available_event_not_emitted(  # noqa: E501
         self, patch_on_orchestrator_available
     ):


### PR DESCRIPTION
# Description

Adds a custom format checker to validate `uri` format in jsonschema.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
