### PR TITLE
Extending interface to support changes of the certifier.pem

### DIFF
--- a/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
+++ b/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
@@ -126,6 +126,7 @@ REQUIRER_JSON_SCHEMA = {
     "examples": [
         {
             "root_ca_certificate": "-----BEGIN CERTIFICATE-----\nMIICvDCCAaQCFFPAOD7utDTsgFrm0vS4We18OcnKMA0GCSqGSIb3DQEBCwUAMCAx\nCzAJBgNVBAYTAlVTMREwDwYDVQQDDAh3aGF0ZXZlcjAeFw0yMjA3MjkyMTE5Mzha\nFw0yMzA3MjkyMTE5MzhaMBUxEzARBgNVBAMMCmJhbmFuYS5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVpcfcBOnFuyZG+A2WQzmaBI5NXgwTCfvE\neKciqRQXhzJdUkEg7eqwFrK3y9yjhoiB6q0WNAeR+nOdS/Cw7layRtGz5skOq7Aa\nN4FZHg0or30i7Rrx7afJcGJyLpxfK/OfLmJm5QEdLXV0DZp0L5vuhhEb1EUOrMaY\nGe4iwqTyg6D7fuBili9dBVn9IvNhYMVgtiqkWVLTW4ChE0LgES4oO3rQZgp4dtM5\nsp6KwHGO766UzwGnkKRizaqmLylfVusllWNPFfp6gEaxa45N70oqGUrvGSVHWeHf\nfvkhpWx+wOnu+2A5F/Yv3UNz2v4g7Vjt7V0tjL4KMV9YklpRjTh3AgMBAAEwDQYJ\nKoZIhvcNAQELBQADggEBAChjRzuba8zjQ7NYBVas89Oy7u++MlS8xWxh++yiUsV6\nWMk3ZemsPtXc1YmXorIQohtxLxzUPm2JhyzFzU/sOLmJQ1E/l+gtZHyRCwsb20fX\nmphuJsMVd7qv/GwEk9PBsk2uDqg4/Wix0Rx5lf95juJP7CPXQJl5FQauf3+LSz0y\nwF/j+4GqvrwsWr9hKOLmPdkyKkR6bHKtzzsxL9PM8GnElk2OpaPMMnzbL/vt2IAt\nxK01ZzPxCQCzVwHo5IJO5NR/fIyFbEPhxzG17QsRDOBR9fl9cOIvDeSO04vyZ+nz\n+kA2c3fNrZFAtpIlOOmFh8Q12rVL4sAjI5mVWnNEgvI=\n-----END CERTIFICATE-----\n",  # noqa: E501
+            "certifier_pem_certificate": "-----BEGIN CERTIFICATE-----\nMIICvDCCAaQCFFPAOD7utDTsgFrm0vS4We18OcnKMA0GCSqGSIb3DQEBCwUAMCAx\nCzAJBgNVBAYTAlVTMREwDwYDVQQDDAh3aGF0ZXZlcjAeFw0yMjA3MjkyMTE5Mzha\nFw0yMzA3MjkyMTE5MzhaMBUxEzARBgNVBAMMCmJhbmFuYS5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVpcfcBOnFuyZG+A2WQzmaBI5NXgwTCfvE\neKciqRQXhzJdUkEg7eqwFrK3y9yjhoiB6q0WNAeR+nOdS/Cw7layRtGz5skOq7Aa\nN4FZHg0or30i7Rrx7afJcGJyLpxfK/OfLmJm5QEdLXV0DZp0L5vuhhEb1EUOrMaY\nGe4iwqTyg6D7fuBili9dBVn9IvNhYMVgtiqkWVLTW4ChE0LgES4oO3rQZgp4dtM5\nsp6KwHGO766UzwGnkKRizaqmLylfVusllWNPFfp6gEaxa45N70oqGUrvGSVHWeHf\nfvkhpWx+wOnu+2A5F/Yv3UNz2v4g7Vjt7V0tjL4KMV9YklpRjTh3AgMBAAEwDQYJ\nKoZIhvcNAQELBQADggEBAChjRzuba8zjQ7NYBVas89Oy7u++MlS8xWxh++yiUsV6\nWMk3ZemsPtXc1YmXorIQohtxLxzUPm2JhyzFzU/sOLmJQ1E/l+gtZHyRCwsb20fX\nmphuJsMVd7qv/GwEk9PBsk2uDqg4/Wix0Rx5lf95juJP7CPXQJl5FQauf3+LSz0y\nwF/j+4GqvrwsWr9hKOLmPdkyKkR6bHKtzzsxL9PM8GnElk2OpaPMMnzbL/vt2IAt\nxK01ZzPxCQCzVwHo5IJO5NR/fIyFbEPhxzG17QsRDOBR9fl9cOIvDeSO04vyZ+nz\n+kA2c3fNrZFAtpIlOOmFh8Q12rVL4sAjI5mVWnNEgvI=\n-----END CERTIFICATE-----\n",  # noqa: E501
             "orchestrator_address": "http://orchestrator.com",
             "orchestrator_port": "1234",
             "bootstrapper_address": "http://bootstrapper.com",
@@ -136,6 +137,9 @@ REQUIRER_JSON_SCHEMA = {
     ],
     "properties": {
         "root_ca_certificate": {
+            "type": "string",
+        },
+        "certifier_pem_certificate": {
             "type": "string",
         },
         "orchestrator_address": {
@@ -162,6 +166,7 @@ REQUIRER_JSON_SCHEMA = {
     },
     "required": [
         "root_ca_certificate",
+        "certifier_pem_certificate",
         "orchestrator_address",
         "orchestrator_port",
         "bootstrapper_address",
@@ -180,6 +185,7 @@ class OrchestratorAvailableEvent(EventBase):
         self,
         handle: Handle,
         root_ca_certificate: str,
+        certifier_pem_certificate: str,
         orchestrator_address: str,
         orchestrator_port: int,
         bootstrapper_address: str,
@@ -190,6 +196,7 @@ class OrchestratorAvailableEvent(EventBase):
         """Init."""
         super().__init__(handle)
         self.root_ca_certificate = root_ca_certificate
+        self.certifier_pem_certificate = certifier_pem_certificate
         self.orchestrator_address = orchestrator_address
         self.orchestrator_port = orchestrator_port
         self.bootstrapper_address = bootstrapper_address
@@ -201,6 +208,7 @@ class OrchestratorAvailableEvent(EventBase):
         """Returns snapshot."""
         return {
             "root_ca_certificate": self.root_ca_certificate,
+            "certifier_pem_certificate": self.certifier_pem_certificate,
             "orchestrator_address": self.orchestrator_address,
             "orchestrator_port": self.orchestrator_port,
             "bootstrapper_address": self.bootstrapper_address,
@@ -212,6 +220,7 @@ class OrchestratorAvailableEvent(EventBase):
     def restore(self, snapshot: dict):
         """Restores snapshot."""
         self.root_ca_certificate = snapshot["root_ca_certificate"]
+        self.certifier_pem_certificate = snapshot["certifier_pem_certificate"]
         self.orchestrator_address = snapshot["orchestrator_address"]
         self.orchestrator_port = snapshot["orchestrator_port"]
         self.bootstrapper_address = snapshot["bootstrapper_address"]
@@ -262,7 +271,7 @@ class OrchestratorRequires(Object):
             return False
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handler triggerred on relation changed events.
+        """Handler triggered on relation changed events.
 
         Args:
             event: Juju event
@@ -277,15 +286,19 @@ class OrchestratorRequires(Object):
         if not relation.app:
             logger.warning(f"No remote application in relation: {self.relationship_name}")
             return
+        if not event.app:
+            logger.warning(f"No remote application for the event: {event}")
+            return
         remote_app_relation_data = relation.data[relation.app]
         if not self._relation_data_is_valid(dict(remote_app_relation_data)):
             logger.warning(
-                f"Provider relation data did not pass JSON Schema validation: "  # type: ignore[index]  # noqa: E501,W505
+                f"Provider relation data did not pass JSON Schema validation: "
                 f"{event.relation.data[event.app]}"
             )
             return
         self.on.orchestrator_available.emit(
             root_ca_certificate=remote_app_relation_data["root_ca_certificate"],
+            certifier_pem_certificate=remote_app_relation_data["certifier_pem_certificate"],
             orchestrator_address=remote_app_relation_data["orchestrator_address"],
             orchestrator_port=int(remote_app_relation_data["orchestrator_port"]),
             bootstrapper_address=remote_app_relation_data["bootstrapper_address"],
@@ -314,6 +327,7 @@ class OrchestratorProvides(Object):
     def set_orchestrator_information(
         self,
         root_ca_certificate: str,
+        certifier_pem_certificate: str,
         orchestrator_address: str,
         bootstrapper_address: str,
         fluentd_address: str,
@@ -325,6 +339,7 @@ class OrchestratorProvides(Object):
 
         Args:
             root_ca_certificate: Orchestrator Root CA Certificate
+            certifier_pem_certificate: Orchestrator `certifier.pem`
             orchestrator_address: Orchestrator address (ex. controller.yourdomain.com)
             bootstrapper_address: Bootstrapper address (ex. bootstrapper-controller.yourdomain.com)
             fluentd_address: Fluentd Address (ex. fluentd.yourdomain.com)
@@ -350,6 +365,7 @@ class OrchestratorProvides(Object):
             relation.data[self.charm.app].update(
                 {
                     "root_ca_certificate": root_ca_certificate,
+                    "certifier_pem_certificate": certifier_pem_certificate,
                     "orchestrator_address": orchestrator_address,
                     "orchestrator_port": str(orchestrator_port),
                     "bootstrapper_address": bootstrapper_address,

--- a/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
+++ b/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
@@ -127,11 +127,11 @@ REQUIRER_JSON_SCHEMA = {
         {
             "root_ca_certificate": "-----BEGIN CERTIFICATE-----\nMIICvDCCAaQCFFPAOD7utDTsgFrm0vS4We18OcnKMA0GCSqGSIb3DQEBCwUAMCAx\nCzAJBgNVBAYTAlVTMREwDwYDVQQDDAh3aGF0ZXZlcjAeFw0yMjA3MjkyMTE5Mzha\nFw0yMzA3MjkyMTE5MzhaMBUxEzARBgNVBAMMCmJhbmFuYS5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVpcfcBOnFuyZG+A2WQzmaBI5NXgwTCfvE\neKciqRQXhzJdUkEg7eqwFrK3y9yjhoiB6q0WNAeR+nOdS/Cw7layRtGz5skOq7Aa\nN4FZHg0or30i7Rrx7afJcGJyLpxfK/OfLmJm5QEdLXV0DZp0L5vuhhEb1EUOrMaY\nGe4iwqTyg6D7fuBili9dBVn9IvNhYMVgtiqkWVLTW4ChE0LgES4oO3rQZgp4dtM5\nsp6KwHGO766UzwGnkKRizaqmLylfVusllWNPFfp6gEaxa45N70oqGUrvGSVHWeHf\nfvkhpWx+wOnu+2A5F/Yv3UNz2v4g7Vjt7V0tjL4KMV9YklpRjTh3AgMBAAEwDQYJ\nKoZIhvcNAQELBQADggEBAChjRzuba8zjQ7NYBVas89Oy7u++MlS8xWxh++yiUsV6\nWMk3ZemsPtXc1YmXorIQohtxLxzUPm2JhyzFzU/sOLmJQ1E/l+gtZHyRCwsb20fX\nmphuJsMVd7qv/GwEk9PBsk2uDqg4/Wix0Rx5lf95juJP7CPXQJl5FQauf3+LSz0y\nwF/j+4GqvrwsWr9hKOLmPdkyKkR6bHKtzzsxL9PM8GnElk2OpaPMMnzbL/vt2IAt\nxK01ZzPxCQCzVwHo5IJO5NR/fIyFbEPhxzG17QsRDOBR9fl9cOIvDeSO04vyZ+nz\n+kA2c3fNrZFAtpIlOOmFh8Q12rVL4sAjI5mVWnNEgvI=\n-----END CERTIFICATE-----\n",  # noqa: E501
             "certifier_pem_certificate": "-----BEGIN CERTIFICATE-----\nMIICvDCCAaQCFFPAOD7utDTsgFrm0vS4We18OcnKMA0GCSqGSIb3DQEBCwUAMCAx\nCzAJBgNVBAYTAlVTMREwDwYDVQQDDAh3aGF0ZXZlcjAeFw0yMjA3MjkyMTE5Mzha\nFw0yMzA3MjkyMTE5MzhaMBUxEzARBgNVBAMMCmJhbmFuYS5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVpcfcBOnFuyZG+A2WQzmaBI5NXgwTCfvE\neKciqRQXhzJdUkEg7eqwFrK3y9yjhoiB6q0WNAeR+nOdS/Cw7layRtGz5skOq7Aa\nN4FZHg0or30i7Rrx7afJcGJyLpxfK/OfLmJm5QEdLXV0DZp0L5vuhhEb1EUOrMaY\nGe4iwqTyg6D7fuBili9dBVn9IvNhYMVgtiqkWVLTW4ChE0LgES4oO3rQZgp4dtM5\nsp6KwHGO766UzwGnkKRizaqmLylfVusllWNPFfp6gEaxa45N70oqGUrvGSVHWeHf\nfvkhpWx+wOnu+2A5F/Yv3UNz2v4g7Vjt7V0tjL4KMV9YklpRjTh3AgMBAAEwDQYJ\nKoZIhvcNAQELBQADggEBAChjRzuba8zjQ7NYBVas89Oy7u++MlS8xWxh++yiUsV6\nWMk3ZemsPtXc1YmXorIQohtxLxzUPm2JhyzFzU/sOLmJQ1E/l+gtZHyRCwsb20fX\nmphuJsMVd7qv/GwEk9PBsk2uDqg4/Wix0Rx5lf95juJP7CPXQJl5FQauf3+LSz0y\nwF/j+4GqvrwsWr9hKOLmPdkyKkR6bHKtzzsxL9PM8GnElk2OpaPMMnzbL/vt2IAt\nxK01ZzPxCQCzVwHo5IJO5NR/fIyFbEPhxzG17QsRDOBR9fl9cOIvDeSO04vyZ+nz\n+kA2c3fNrZFAtpIlOOmFh8Q12rVL4sAjI5mVWnNEgvI=\n-----END CERTIFICATE-----\n",  # noqa: E501
-            "orchestrator_address": "http://orchestrator.com",
+            "orchestrator_address": "orchestrator.com",
             "orchestrator_port": "1234",
-            "bootstrapper_address": "http://bootstrapper.com",
+            "bootstrapper_address": "bootstrapper.com",
             "bootstrapper_port": "5678",
-            "fluentd_address": "http://fluentd.com",
+            "fluentd_address": "fluentd.com",
             "fluentd_port": "9112",
         }
     ],

--- a/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
+++ b/lib/charms/magma_orchestrator_interface/v0/magma_orchestrator_interface.py
@@ -113,7 +113,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -144,21 +144,18 @@ REQUIRER_JSON_SCHEMA = {
         },
         "orchestrator_address": {
             "type": "string",
-            "format": "uri",
         },
         "orchestrator_port": {
             "type": "string",
         },
         "bootstrapper_address": {
             "type": "string",
-            "format": "uri",
         },
         "bootstrapper_port": {
             "type": "string",
         },
         "fluentd_address": {
             "type": "string",
-            "format": "uri",
         },
         "fluentd_port": {
             "type": "string",

--- a/tests/unit/charms/magma_orchestrator_interface/v0/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/magma_orchestrator_interface/v0/dummy_provider_charm/src/charm.py
@@ -17,6 +17,7 @@ class DummyMagmaOrchestratorProviderCharm(CharmBase):
     """Charm the service."""
 
     DUMMY_ROOT_CA_CERT = "whatever certificate content"
+    DUMMY_CERTIFIER_PEM = "whatever certifier pem content"
     DUMMY_ORC8R_ADDRESS = "http://orchestrator.com"
     DUMMY_ORC8C_PORT = 1234
     DUMMY_BOOTSTRAPPER_ADDRESS = "http://bootstrapper.com"
@@ -36,6 +37,7 @@ class DummyMagmaOrchestratorProviderCharm(CharmBase):
         if self.unit.is_leader():
             self.orchestrator_provider.set_orchestrator_information(
                 root_ca_certificate=self.DUMMY_ROOT_CA_CERT,
+                certifier_pem_certificate=self.DUMMY_CERTIFIER_PEM,
                 orchestrator_address=self.DUMMY_ORC8R_ADDRESS,
                 orchestrator_port=self.DUMMY_ORC8C_PORT,
                 bootstrapper_address=self.DUMMY_BOOTSTRAPPER_ADDRESS,

--- a/tests/unit/charms/magma_orchestrator_interface/v0/test_magma_orchestrator_interface_provider.py
+++ b/tests/unit/charms/magma_orchestrator_interface/v0/test_magma_orchestrator_interface_provider.py
@@ -17,6 +17,7 @@ testing.SIMULATE_CAN_CONNECT = True
 
 DUMMY_PROVIDER_CHARM = "tests.unit.charms.magma_orchestrator_interface.v0.dummy_provider_charm.src.charm.DummyMagmaOrchestratorProviderCharm"  # noqa: E501
 TEST_ROOT_CA_CERT = "whatever ca certificate"
+TEST_CERTIFIER_PEM_CERT = "whatever certifier pem"
 TEST_ORC8R_ADDRESS = "orchestrator.com"
 TEST_ORC8R_PORT = 1111
 TEST_BOOTSTRAPPER_ADDRESS = "bootstrapper.com"
@@ -33,6 +34,7 @@ class TestMagmaOrchestratorProvider(unittest.TestCase):
         self.harness.begin()
 
     @patch(f"{DUMMY_PROVIDER_CHARM}.DUMMY_ROOT_CA_CERT", new_callable=PropertyMock)
+    @patch(f"{DUMMY_PROVIDER_CHARM}.DUMMY_CERTIFIER_PEM", new_callable=PropertyMock)
     @patch(f"{DUMMY_PROVIDER_CHARM}.DUMMY_ORC8R_ADDRESS", new_callable=PropertyMock)
     @patch(f"{DUMMY_PROVIDER_CHARM}.DUMMY_ORC8C_PORT", new_callable=PropertyMock)
     @patch(f"{DUMMY_PROVIDER_CHARM}.DUMMY_BOOTSTRAPPER_ADDRESS", new_callable=PropertyMock)
@@ -47,12 +49,13 @@ class TestMagmaOrchestratorProvider(unittest.TestCase):
         patched_bootstrapper_address,
         patched_orc8r_port,
         patched_orc8r_address,
+        patched_certifier_pem,
         patched_root_ca,
     ):
-
         self.harness.set_leader(is_leader=True)
         remote_app = "magma-orc8r-requirer"
         patched_root_ca.return_value = TEST_ROOT_CA_CERT
+        patched_certifier_pem.return_value = TEST_CERTIFIER_PEM_CERT
         patched_orc8r_address.return_value = TEST_ORC8R_ADDRESS
         patched_orc8r_port.return_value = TEST_ORC8R_PORT
         patched_bootstrapper_address.return_value = TEST_BOOTSTRAPPER_ADDRESS
@@ -69,6 +72,7 @@ class TestMagmaOrchestratorProvider(unittest.TestCase):
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
         self.assertEqual(relation_data["root_ca_certificate"], TEST_ROOT_CA_CERT)
+        self.assertEqual(relation_data["certifier_pem_certificate"], TEST_CERTIFIER_PEM_CERT)
         self.assertEqual(relation_data["orchestrator_address"], TEST_ORC8R_ADDRESS)
         self.assertEqual(relation_data["orchestrator_port"], str(TEST_ORC8R_PORT))
         self.assertEqual(relation_data["bootstrapper_address"], TEST_BOOTSTRAPPER_ADDRESS)
@@ -77,6 +81,7 @@ class TestMagmaOrchestratorProvider(unittest.TestCase):
         self.assertEqual(relation_data["fluentd_port"], str(TEST_FLUENTD_PORT))
 
     @patch(f"{DUMMY_PROVIDER_CHARM}.DUMMY_ROOT_CA_CERT", new_callable=PropertyMock)
+    @patch(f"{DUMMY_PROVIDER_CHARM}.DUMMY_CERTIFIER_PEM", new_callable=PropertyMock)
     @patch(f"{DUMMY_PROVIDER_CHARM}.DUMMY_ORC8R_ADDRESS", new_callable=PropertyMock)
     @patch(f"{DUMMY_PROVIDER_CHARM}.DUMMY_ORC8C_PORT", new_callable=PropertyMock)
     @patch(f"{DUMMY_PROVIDER_CHARM}.DUMMY_BOOTSTRAPPER_ADDRESS", new_callable=PropertyMock)
@@ -91,13 +96,14 @@ class TestMagmaOrchestratorProvider(unittest.TestCase):
         patched_bootstrapper_address,
         patched_orc8r_port,
         patched_orc8r_address,
+        patched_certifier_pem,
         patched_root_ca,
     ):
-
         self.harness.set_leader(is_leader=True)
         remote_app = "magma-orc8r-requirer"
         remote_app_2 = "another-magma-orc8r-requirer"
         patched_root_ca.return_value = TEST_ROOT_CA_CERT
+        patched_certifier_pem.return_value = TEST_CERTIFIER_PEM_CERT
         patched_orc8r_address.return_value = TEST_ORC8R_ADDRESS
         patched_orc8r_port.return_value = TEST_ORC8R_PORT
         patched_bootstrapper_address.return_value = TEST_BOOTSTRAPPER_ADDRESS
@@ -118,6 +124,7 @@ class TestMagmaOrchestratorProvider(unittest.TestCase):
             relation_id=relation_one_id, app_or_unit=self.harness.charm.app.name
         )
         self.assertEqual(relation_one_data["root_ca_certificate"], TEST_ROOT_CA_CERT)
+        self.assertEqual(relation_one_data["certifier_pem_certificate"], TEST_CERTIFIER_PEM_CERT)
         self.assertEqual(relation_one_data["orchestrator_address"], TEST_ORC8R_ADDRESS)
         self.assertEqual(relation_one_data["orchestrator_port"], str(TEST_ORC8R_PORT))
         self.assertEqual(relation_one_data["bootstrapper_address"], TEST_BOOTSTRAPPER_ADDRESS)
@@ -129,6 +136,7 @@ class TestMagmaOrchestratorProvider(unittest.TestCase):
             relation_id=relation_two_id, app_or_unit=self.harness.charm.app.name
         )
         self.assertEqual(relation_two_data["root_ca_certificate"], TEST_ROOT_CA_CERT)
+        self.assertEqual(relation_two_data["certifier_pem_certificate"], TEST_CERTIFIER_PEM_CERT)
         self.assertEqual(relation_two_data["orchestrator_address"], TEST_ORC8R_ADDRESS)
         self.assertEqual(relation_two_data["orchestrator_port"], str(TEST_ORC8R_PORT))
         self.assertEqual(relation_two_data["bootstrapper_address"], TEST_BOOTSTRAPPER_ADDRESS)
@@ -146,6 +154,7 @@ class TestMagmaOrchestratorProvider(unittest.TestCase):
         with pytest.raises(RuntimeError) as e:
             self.harness.charm.orchestrator_provider.set_orchestrator_information(
                 root_ca_certificate=TEST_ROOT_CA_CERT,
+                certifier_pem_certificate=TEST_CERTIFIER_PEM_CERT,
                 orchestrator_address=TEST_ORC8R_ADDRESS,
                 orchestrator_port=TEST_ORC8R_PORT,
                 bootstrapper_address=TEST_BOOTSTRAPPER_ADDRESS,
@@ -163,6 +172,7 @@ class TestMagmaOrchestratorProvider(unittest.TestCase):
         with pytest.raises(RuntimeError) as e:
             self.harness.charm.orchestrator_provider.set_orchestrator_information(
                 root_ca_certificate=TEST_ROOT_CA_CERT,
+                certifier_pem_certificate=TEST_CERTIFIER_PEM_CERT,
                 orchestrator_address=TEST_ORC8R_ADDRESS,
                 orchestrator_port=TEST_ORC8R_PORT,
                 bootstrapper_address=TEST_BOOTSTRAPPER_ADDRESS,
@@ -195,6 +205,7 @@ class TestMagmaOrchestratorProvider(unittest.TestCase):
         with pytest.raises(ValueError) as e:
             self.harness.charm.orchestrator_provider.set_orchestrator_information(
                 root_ca_certificate=TEST_ROOT_CA_CERT,
+                certifier_pem_certificate=TEST_CERTIFIER_PEM_CERT,
                 orchestrator_address=TEST_ORC8R_ADDRESS,
                 orchestrator_port=orchestrator_port,
                 bootstrapper_address=TEST_BOOTSTRAPPER_ADDRESS,

--- a/tests/unit/charms/magma_orchestrator_interface/v0/test_magma_orchestrator_interface_requirer.py
+++ b/tests/unit/charms/magma_orchestrator_interface/v0/test_magma_orchestrator_interface_requirer.py
@@ -34,11 +34,11 @@ class Test(unittest.TestCase):
 
         root_ca_certificate = "whatever certificate"
         certifier_pem_certificate = "whatever certifier pem"
-        orchestrator_address = "http://orchestrator.com"
+        orchestrator_address = "orchestrator.com"
         orchestrator_port = 123
-        bootstrapper_address = "http://bootstrapper.com"
+        bootstrapper_address = "bootstrapper.com"
         bootstrapper_port = 456
-        fluentd_address = "http://fluentd.com"
+        fluentd_address = "fluentd.com"
         fluentd_port = 789
         remote_app_relation_data = {
             "root_ca_certificate": root_ca_certificate,
@@ -69,39 +69,6 @@ class Test(unittest.TestCase):
         self.assertEqual(orchestrator_available_event.fluentd_port, fluentd_port)
 
     @patch(f"{BASE_CHARM_DIR}._on_orchestrator_available")
-    def test_given_orchestrator_information_in_relation_data_when_relation_changed_and_schema_validation_fails_then_orchestrator_available_event_is_not_emitted(  # noqa: E501
-        self, patch_on_orchestrator_available
-    ):
-        remote_app = "magma-orc8r-provider"
-        relation_id = self.harness.add_relation(
-            relation_name=self.relation_name, remote_app=remote_app
-        )
-
-        root_ca_certificate = "whatever certificate"
-        certifier_pem_certificate = "whatever certifier pem"
-        wrong_orchestrator_address = "not a url"
-        orchestrator_port = 123
-        bootstrapper_address = "http://bootstrapper.com"
-        bootstrapper_port = 456
-        fluentd_address = "http://fluentd.com"
-        fluentd_port = 789
-        remote_app_relation_data = {
-            "root_ca_certificate": root_ca_certificate,
-            "certifier_pem_certificate": certifier_pem_certificate,
-            "orchestrator_address": wrong_orchestrator_address,
-            "orchestrator_port": str(orchestrator_port),
-            "bootstrapper_address": bootstrapper_address,
-            "bootstrapper_port": str(bootstrapper_port),
-            "fluentd_address": fluentd_address,
-            "fluentd_port": str(fluentd_port),
-        }
-        self.harness.update_relation_data(
-            relation_id=relation_id, app_or_unit=remote_app, key_values=remote_app_relation_data
-        )
-
-        patch_on_orchestrator_available.assert_not_called()
-
-    @patch(f"{BASE_CHARM_DIR}._on_orchestrator_available")
     def test_given_orchestrator_information_not_in_relation_data_when_relation_changed_then_orchestrator_available_event_not_emitted(  # noqa: E501
         self, patch_on_orchestrator_available
     ):
@@ -124,9 +91,9 @@ class Test(unittest.TestCase):
         relation_id = self.harness.add_relation(
             relation_name=self.relation_name, remote_app=remote_app
         )
-        orchestrator_address = "http://orchestrator.com"
+        orchestrator_address = "orchestrator.com"
         orchestrator_port = 123
-        bootstrapper_address = "http://bootstrapper.com"
+        bootstrapper_address = "bootstrapper.com"
         bootstrapper_port = 456
         remote_app_relation_data = {
             "orchestrator_address": orchestrator_address,

--- a/tests/unit/charms/magma_orchestrator_interface/v0/test_magma_orchestrator_interface_requirer.py
+++ b/tests/unit/charms/magma_orchestrator_interface/v0/test_magma_orchestrator_interface_requirer.py
@@ -33,6 +33,7 @@ class Test(unittest.TestCase):
         )
 
         root_ca_certificate = "whatever certificate"
+        certifier_pem_certificate = "whatever certifier pem"
         orchestrator_address = "http://orchestrator.com"
         orchestrator_port = 123
         bootstrapper_address = "http://bootstrapper.com"
@@ -41,6 +42,7 @@ class Test(unittest.TestCase):
         fluentd_port = 789
         remote_app_relation_data = {
             "root_ca_certificate": root_ca_certificate,
+            "certifier_pem_certificate": certifier_pem_certificate,
             "orchestrator_address": orchestrator_address,
             "orchestrator_port": str(orchestrator_port),
             "bootstrapper_address": bootstrapper_address,
@@ -56,6 +58,9 @@ class Test(unittest.TestCase):
         args, _ = patch_on_orchestrator_available.call_args
         orchestrator_available_event = args[0]
         self.assertEqual(orchestrator_available_event.root_ca_certificate, root_ca_certificate)
+        self.assertEqual(
+            orchestrator_available_event.certifier_pem_certificate, certifier_pem_certificate
+        )
         self.assertEqual(orchestrator_available_event.orchestrator_address, orchestrator_address)
         self.assertEqual(orchestrator_available_event.orchestrator_port, orchestrator_port)
         self.assertEqual(orchestrator_available_event.bootstrapper_address, bootstrapper_address)
@@ -73,6 +78,7 @@ class Test(unittest.TestCase):
         )
 
         root_ca_certificate = "whatever certificate"
+        certifier_pem_certificate = "whatever certifier pem"
         wrong_orchestrator_address = "not a url"
         orchestrator_port = 123
         bootstrapper_address = "http://bootstrapper.com"
@@ -81,6 +87,7 @@ class Test(unittest.TestCase):
         fluentd_port = 789
         remote_app_relation_data = {
             "root_ca_certificate": root_ca_certificate,
+            "certifier_pem_certificate": certifier_pem_certificate,
             "orchestrator_address": wrong_orchestrator_address,
             "orchestrator_port": str(orchestrator_port),
             "bootstrapper_address": bootstrapper_address,


### PR DESCRIPTION
# Description

Extends `magma-orchestrator-interface` to support changes of the `certifier.pem`. This will be used to reconfigure AGW whenever a CA used to sign AGW's certs changes.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
